### PR TITLE
Fixed #67 - new goal build-helper:is-release

### DIFF
--- a/src/main/java/org/codehaus/mojo/buildhelper/ParseVersionMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/ParseVersionMojo.java
@@ -15,6 +15,8 @@ import org.codehaus.mojo.buildhelper.versioning.DefaultVersioning;
  *   [propertyPrefix].incrementalVersion
  *   [propertyPrefix].qualifier
  *   [propertyPrefix].buildNumber
+ *   [propertyPrefix].isRelease
+ *   [propertyPrefix].isSnapshot
  * </pre>
  * 
  * Where the propertyPrefix is the string set in the mojo parameter. The parsing of the above is based on the following
@@ -164,6 +166,11 @@ public class ParseVersionMojo
         defineProperty( propertyPrefix + '.' + name, value );
     }
 
+    private void defineVersionProperty( String name, Boolean value )
+    {
+        defineProperty( propertyPrefix + '.' + name, value.toString() );
+    }
+
     private void defineFormattedVersionProperty( String name, String value )
     {
         defineProperty( formattedPropertyPrefix + '.' + name, value );
@@ -194,11 +201,15 @@ public class ParseVersionMojo
         getLog().debug( "   incremental: " + artifactVersion.getPatch() );
         getLog().debug( "   buildnumber: " + artifactVersion.getBuildNumber() );
         getLog().debug( "     qualifier: " + artifactVersion.getQualifier() );
+        getLog().debug( "     isRelease: " + artifactVersion.isRelease() );
+        getLog().debug( "    isSnapshot: " + artifactVersion.isSnapshot() );
 
         defineVersionProperty( "majorVersion", artifactVersion.getMajor() );
         defineVersionProperty( "minorVersion", artifactVersion.getMinor() );
         defineVersionProperty( "incrementalVersion", artifactVersion.getPatch() );
         defineVersionProperty( "buildNumber", artifactVersion.getBuildNumber() );
+        defineVersionProperty( "isSnapshot", artifactVersion.isSnapshot() );
+        defineVersionProperty( "isRelease", artifactVersion.isRelease() );
 
         defineVersionProperty( "nextMajorVersion", artifactVersion.getMajor() + 1 );
         defineVersionProperty( "nextMinorVersion", artifactVersion.getMinor() + 1 );

--- a/src/main/java/org/codehaus/mojo/buildhelper/versioning/DefaultVersioning.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/versioning/DefaultVersioning.java
@@ -68,6 +68,14 @@ public class DefaultVersioning
         return osgiVersion.toString();
     }
 
+    public boolean isSnapshot() {
+        return this.version.endsWith("-SNAPSHOT");
+    }
+
+    public boolean isRelease() {
+        return !isSnapshot();
+    }
+
     @Override
     public long getBuildNumber()
     {

--- a/src/main/java/org/codehaus/mojo/buildhelper/versioning/Versioning.java
+++ b/src/main/java/org/codehaus/mojo/buildhelper/versioning/Versioning.java
@@ -15,4 +15,8 @@ public interface Versioning
 
     String getQualifier();
 
+    boolean isRelease();
+
+    boolean isSnapshot();
+
 }

--- a/src/test/java/org/codehaus/mojo/buildhelper/ParseVersionTest.java
+++ b/src/test/java/org/codehaus/mojo/buildhelper/ParseVersionTest.java
@@ -99,6 +99,8 @@ public class ParseVersionTest
             assertEquals( "", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "0", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "1.0.0", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "true", props.getProperty( "parsed.isRelease" ) );
+            assertEquals( "false", props.getProperty( "parsed.isSnapshot" ) );
         }
 
         @Test
@@ -113,6 +115,8 @@ public class ParseVersionTest
             assertEquals( "beta-5", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "0", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "2.3.4.beta-5", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "true", props.getProperty( "parsed.isRelease" ) );
+            assertEquals( "false", props.getProperty( "parsed.isSnapshot" ) );
         }
 
         @Test
@@ -127,6 +131,8 @@ public class ParseVersionTest
             assertEquals( "beta_5", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "0", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "2.3.4.beta_5", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "true", props.getProperty( "parsed.isRelease" ) );
+            assertEquals( "false", props.getProperty( "parsed.isSnapshot" ) );
         }
 
         @Test
@@ -141,6 +147,8 @@ public class ParseVersionTest
             assertEquals( "SNAPSHOT", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "0", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "1.2.3.SNAPSHOT", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "false", props.getProperty( "parsed.isRelease" ) );
+            assertEquals( "true", props.getProperty( "parsed.isSnapshot" ) );
         }
 
         @Test
@@ -155,6 +163,8 @@ public class ParseVersionTest
             assertEquals( "SNAPSHOT", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "0", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "2.0.17.SNAPSHOT", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "false", props.getProperty( "parsed.isRelease" ) );
+            assertEquals( "true", props.getProperty( "parsed.isSnapshot" ) );
         }
 
         @Test
@@ -169,6 +179,8 @@ public class ParseVersionTest
             assertEquals( "", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "4", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "1.2.3.4", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "true", props.getProperty( "parsed.isRelease" ) );
+            assertEquals( "false", props.getProperty( "parsed.isSnapshot" ) );
 
         }
 
@@ -184,6 +196,8 @@ public class ParseVersionTest
             assertEquals( "-SNAPSHOT", props.getProperty( "parsed.qualifier" ) );
             assertEquals( "4", props.getProperty( "parsed.buildNumber" ) );
             assertEquals( "1.2.3.4-SNAPSHOT", props.getProperty( "parsed.osgiVersion" ) );
+            assertEquals( "false", props.getProperty( "parsed.isRelease" ) );
+            assertEquals( "true", props.getProperty( "parsed.isSnapshot" ) );
         }
 
     }


### PR DESCRIPTION
 o We have added supplemental properties which represent
   if it's an release/snapshot instead.